### PR TITLE
Add build file for sonarqube integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available.
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=software2uis_msv-catalogo_34da7681-66f8-47eb-bb1d-94e32f07802b -Dsonar.projectName='msv-catalogo'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and analysis process for the project. The workflow is configured to trigger on pushes to the `main` branch and includes steps for setting up the environment, caching dependencies, and running the build and analysis.

Key changes include:

* Added a new workflow configuration in `.github/workflows/build.yml` to automate the build and analysis process.
  * Configured the workflow to trigger on pushes to the `main` branch.
  * Set up the job to run on `ubuntu-latest`.
  * Included steps to:
    * Check out the repository.
    * Set up JDK 17 using the `actions/setup-java` action.
    * Cache SonarQube and Maven packages.
    * Run the build and SonarQube analysis using Maven.
 
This PR closes #13 