### PR TITLE
feat: modify build to be triggered not only on pushes but also on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+      types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -37,4 +37,5 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=software2uis_msv-catalogo_34da7681-66f8-47eb-bb1d-94e32f07802b -Dsonar.projectName='msv-catalogo'
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=software2uis_msv-catalogo_ce70f7d9-dff4-4cd7-b766-46698d6ef9b4 -Dsonar.projectName='msv-catalogo'
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          MONGODBURI: ${{ secrets.MONGODBURI }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=software2uis_msv-catalogo_ce70f7d9-dff4-4cd7-b766-46698d6ef9b4 -Dsonar.projectName='msv-catalogo'
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/application.properties
+++ b/application.properties
@@ -1,0 +1,1 @@
+spring.data.mongodb.uri=${MONGODBURI}


### PR DESCRIPTION
This pull request includes a small change to the GitHub Actions workflow configuration file `.github/workflows/build.yml`. The change ensures that the build job is triggered not only on pushes to the `main` branch but also on pull request events.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L7-R8): Added `pull_request` event with types `[opened, synchronize, reopened]` to trigger the build job.